### PR TITLE
Add test for handling dag importing from another python file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN python -m venv /opt/venv
 ENV PYTHON_VERSION 3.7
 ENV AIRFLOW_VERSION=2.2.4
 ENV CONSTRAINT_URL "https://raw.githubusercontent.com/apache/airflow/constraints-${AIRFLOW_VERSION}/constraints-${PYTHON_VERSION}.txt"
-RUN pip install "apache-airflow[async,postgres,google]==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
+RUN pip install "apache-airflow[async,postgres,google,cncf.kubernetes]==${AIRFLOW_VERSION}" --constraint "${CONSTRAINT_URL}"
 
 # Install Deps
 RUN pip install google-cloud-storage

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,6 +12,8 @@ airflow variables import $3
 
 cp -r /action/* /github/workspace/
 
+export PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${PWD}/$2"
+
 pytest dag_validation.py -s -q >> result.log
 pytest_exit_code=`echo Pytest exited $?`
 echo $pytest_exit_code

--- a/tests/dags/shared_var.py
+++ b/tests/dags/shared_var.py
@@ -1,0 +1,1 @@
+image = "ubuntu:21.10"

--- a/tests/dags/test_dag.py
+++ b/tests/dags/test_dag.py
@@ -35,6 +35,7 @@ dag = DAG(
 
 def test_import_module():
     import prettyprint
+    from shared_var import image
     return True
 
 


### PR DESCRIPTION
Fixes #21 

# Change summary
- Add export `PYTHONPATH` to `entry.sh`
- Add `KubernetesPodOperator` to `test_dag.py`
- Dockerfile to build `airflow[cnf.kubernets]` library

# Reason
Most of our dags runs `KubernetesPodOperator`, the infrastructure team provides guidance on the configuration for the pod. This configuration file acts as a middleman for the dag developers and infrastructure maintainers. It's essential for dag action to be able to import `shared/common` python file within the `Dag` folder