### PR TITLE
display conn var and plugin in comment log

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,15 +10,23 @@ echo "Load examples : $6"
 
 pip install -r $1
 
+export AIRFLOW__CORE__LOAD_DEFAULT_CONNECTIONS="False"
+
 airflow db init
+
 airflow variables import $3
 airflow connections import $4
+
 
 cp -r /action/* /github/workspace/
 
 export PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}${PWD}/$2"
 export AIRFLOW__CORE__PLUGINS_FOLDER="${PWD}/$5"
 export AIRFLOW__CORE__LOAD_EXAMPLES="$6"
+
+airflow variables list >> result.log
+airflow connections list >> result.log
+airflow plugins >> result.log
 
 pytest dag_validation.py -s -q >> result.log
 pytest_exit_code=`echo Pytest exited $?`

--- a/tests/plugins/common/utils.py
+++ b/tests/plugins/common/utils.py
@@ -1,3 +1,6 @@
+from airflow.plugins_manager import AirflowPlugin
+import airflow.utils.python_virtualenv
+
 import datetime as dt
 from datetime import timedelta
 
@@ -13,3 +16,8 @@ def days_ago(n, hour=0, minute=0, second=0, microsecond=0, timezone="utc"):
         hour=hour, minute=minute, second=second, microsecond=microsecond
     )
     return today - timedelta(days=n)
+
+airflow.utils.python_virtualenv._generate_virtualenv_cmd=days_ago
+
+class VirtualPythonPlugin(AirflowPlugin):
+    name = 'days_ago_plugin'


### PR DESCRIPTION
> This is a new release [v2.3](https://github.com/jayamanikharyono/airflow-dag-action/releases/tag/v2.3) Since you are adding plugins and connections, is that any way to print out those plugins and connections listed to the PR comment? @pindge

